### PR TITLE
fix pwd in neovim for alacritty

### DIFF
--- a/src/backend/alacritty.rs
+++ b/src/backend/alacritty.rs
@@ -57,6 +57,12 @@ impl Functions for Alacritty {
         command.arg(self.temp_file.as_ref().unwrap().path());
         command.arg("--class");
         command.arg("glrnvim");
+
+        if let Ok(current_dir) = std::env::current_dir() {
+            command.arg("--working-directory");
+            command.arg(current_dir);
+        }
+
         command.arg("-e");
         command.arg(NVIM_NAME);
 


### PR DESCRIPTION
fixes pwd in neovim when open glrnvim not from home directory
and also if the path to the file or folder is not from the home directory
example
```bash
cd ~/working_dir
glrnvim new_file.txt
```
glrnvim create file in home directory `~/new_file.txt`
