### PR TITLE
Fix pwd in neovim for alacritty

### DIFF
--- a/src/backend/alacritty.rs
+++ b/src/backend/alacritty.rs
@@ -60,9 +60,11 @@ impl Functions for Alacritty {
         command.arg("--class");
         command.arg("glrnvim");
 
-        if let Ok(current_dir) = std::env::current_dir() {
-            command.arg("--working-directory");
-            command.arg(current_dir);
+        if cfg!(target_os = "macos") {
+            if let Ok(current_dir) = std::env::current_dir() {
+                command.arg("--working-directory");
+                command.arg(current_dir);
+            }
         }
 
         command.arg("-e");


### PR DESCRIPTION
add target_os condition
As you said [here](https://github.com/beeender/glrnvim/pull/13#issuecomment-573391143), this fix is only needed for mac os

