### PR TITLE
Make installation instructions clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Install `glrnvim` from the AUR.
 cargo install cargo-deb
 ```
 
-- Build and install the `deb` package system-wide.
+- Clone the project. Then build and install the `deb` package system-wide by running the following command from the project's root directory.
 
 ```
 cargo deb --install


### PR DESCRIPTION
Just a very small change in the install instructions for Debian/Ubuntu. As a person who hasn't used rust for programming before it wasn't entirely clear to me what the instructions meant.
I figured it out by briefly looking at the cargo-deb repo. Just thought this small change might make things clearer for less experienced developers. 
Thanks for the project, it's great and I'm using glrnvim a lot!