### PR TITLE
Add wezterm support

### DIFF
--- a/src/backend/kitty.rs
+++ b/src/backend/kitty.rs
@@ -54,7 +54,7 @@ impl Kitty {
     // $XDG_CONFIG_HOME/kitty/kitty.conf
     // ~/.config/kitty/kitty.conf,
     // $XDG_CONFIG_DIRS/kitty/kitty.conf
-    fn find_deafult_confs() -> Vec<String> {
+    fn find_default_confs() -> Vec<String> {
         let base_confs: [String; 1] = ["/etc/xdg/kitty/kitty.conf".to_string()];
         let pri_confs: [String; 4] = [
             "$KITTY_CONFIG_DIRECTORY/kitty.conf".to_string(),
@@ -72,7 +72,7 @@ impl Functions for Kitty {
         let mut command = std::process::Command::new(self.exe_path.to_owned());
 
         if config.load_term_conf {
-            let confs = Kitty::find_deafult_confs();
+            let confs = Kitty::find_default_confs();
             for conf in confs {
                 command.arg("--config");
                 command.arg(conf);

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,6 +1,7 @@
 mod alacritty;
 mod kitty;
 mod urxvt;
+mod wezterm;
 use super::config::Config;
 use crate::config::Backend;
 use crate::error::GlrnvimError;
@@ -13,8 +14,9 @@ pub trait Functions {
 
 const COMMON_ARGS: &'static [&'static str] = &[
     "+set termguicolors", // Enable 24-bits colors
-    "+set title", // Set title string
-    "--cmd", "let g:glrnvim_gui=1",
+    "+set title",         // Set title string
+    "--cmd",
+    "let g:glrnvim_gui=1",
 ];
 
 pub fn init(config: &Config) -> Result<Box<dyn Functions>, GlrnvimError> {
@@ -23,9 +25,10 @@ pub fn init(config: &Config) -> Result<Box<dyn Functions>, GlrnvimError> {
             Backend::Alacritty => alacritty::init(config),
             Backend::Urxvt => urxvt::init(config),
             Backend::Kitty => kitty::init(config),
+            Backend::Wezterm => wezterm::init(config),
         },
         None => {
-            for init_func in &[alacritty::init, urxvt::init, kitty::init] {
+            for init_func in &[alacritty::init, urxvt::init, kitty::init, wezterm::init] {
                 match init_func(config) {
                     Ok(functions) => return Ok(functions),
                     Err(_) => {}
@@ -54,8 +57,7 @@ fn find_executable(exe_name: &str) -> Result<PathBuf, GlrnvimError> {
         Ok(p) => Ok(p),
         Err(e) => Err(GlrnvimError::new(format!(
             "'{}' executable cannot be found. {}",
-            exe_name,
-            e
+            exe_name, e
         ))),
     }
 }

--- a/src/backend/wezterm.rs
+++ b/src/backend/wezterm.rs
@@ -31,8 +31,7 @@ impl Wezterm {
             for font in &config.fonts {
                 fn_arg.push('\"');
                 fn_arg.push_str(font);
-                fn_arg.push('\"');
-                fn_arg.push(',');
+                fn_arg.push_str("\",");
             }
             fn_arg.push_str("})");
         }

--- a/src/backend/wezterm.rs
+++ b/src/backend/wezterm.rs
@@ -29,7 +29,7 @@ impl Wezterm {
             self.args.push("--config".to_string());
             fn_arg = String::from("font=require('wezterm').font_with_fallback({");
             for font in &config.fonts {
-                fn_arg = fn_arg + "\"" + &font[..] + "\",";
+                fn_arg = format!("{} \"{}\",", fn_arg, font);
             }
             fn_arg.push_str("})");
         }

--- a/src/backend/wezterm.rs
+++ b/src/backend/wezterm.rs
@@ -29,7 +29,7 @@ impl Wezterm {
         let mut fn_arg = String::from("");
         if !&config.fonts.is_empty() {
             self.args.push("--config".to_string());
-            fn_arg = String::from("font=require('wezterm').font_with_fallback({");
+            fn_arg = String::from("font = require('wezterm').font_with_fallback({");
             for font in &config.fonts {
                 fn_arg = format!("{} \"{}\",", fn_arg, font);
             }
@@ -42,6 +42,8 @@ impl Wezterm {
             self.args.push("--config".to_string());
             self.args.push(format!("font_size={}", config.font_size));
         }
+        self.args.push("--config".to_string());
+        self.args.push("enable_tab_bar = false".to_string());
     }
     fn create_conf_file(&mut self) {
         let mut file = tempfile::NamedTempFile::new().unwrap();

--- a/src/backend/wezterm.rs
+++ b/src/backend/wezterm.rs
@@ -29,9 +29,7 @@ impl Wezterm {
             self.args.push("--config".to_string());
             fn_arg = String::from("font=require('wezterm').font_with_fallback({");
             for font in &config.fonts {
-                fn_arg.push('\"');
-                fn_arg.push_str(font);
-                fn_arg.push_str("\",");
+                fn_arg = fn_arg + "\"" + &font[..] + "\",";
             }
             fn_arg.push_str("})");
         }

--- a/src/backend/wezterm.rs
+++ b/src/backend/wezterm.rs
@@ -1,0 +1,70 @@
+use super::Functions;
+use crate::config::Config;
+use crate::error::GlrnvimError;
+use crate::NVIM_NAME;
+use std::io::Write;
+use std::path::PathBuf;
+
+pub const WEZTERM_NAME: &str = "wezterm";
+
+struct Wezterm {
+    exe_path: PathBuf,
+    pub args: Vec<String>,
+}
+
+pub fn init(config: &Config) -> Result<Box<dyn Functions>, GlrnvimError> {
+    let exe_path = super::exe_path(&config.exe_path, WEZTERM_NAME)?;
+
+    Ok(Box::new(Wezterm {
+        exe_path,
+        args: vec![],
+    }))
+}
+
+impl Wezterm {
+    fn init_args(&mut self, config: &Config) {
+        let mut fn_arg = String::from("");
+        if !&config.fonts.is_empty() {
+            self.args.push("--config".to_string());
+            fn_arg = String::from("font=require('wezterm').font_with_fallback({");
+            for font in &config.fonts {
+                fn_arg.push('\"');
+                fn_arg.push_str(font);
+                fn_arg.push('\"');
+                fn_arg.push(',');
+            }
+            fn_arg.push_str("})");
+        }
+        if !fn_arg.is_empty() {
+            self.args.push(fn_arg);
+        }
+        if config.font_size != 0 {
+            self.args.push("--config".to_string());
+            self.args
+                .push(format!("font_size={}", config.font_size));
+        }
+    }
+}
+
+impl Functions for Wezterm {
+    fn create_command(&mut self, config: &Config) -> std::process::Command {
+        self.init_args(config);
+        let mut command = std::process::Command::new(self.exe_path.to_owned());
+        command.args(&self.args);
+        if !config.load_term_conf {
+            command.arg("--config-file");
+            let mut file = tempfile::NamedTempFile::new().unwrap();
+            writeln!(file, "return {{}}").unwrap();
+            file.flush().unwrap();
+            file.path();
+            command.arg(Some(file).as_ref().unwrap().path());
+        }
+        command.arg("start");
+        command.arg("--class");
+        command.arg("glrnvim");
+        command.arg("--");
+        command.arg(NVIM_NAME);
+        command.args(super::COMMON_ARGS);
+        command
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ pub enum Backend {
     Alacritty,
     Urxvt,
     Kitty,
+    Wezterm,
 }
 
 #[derive(Debug, PartialEq, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,7 +51,7 @@ pub fn parse(path: PathBuf, fork: bool) -> Config {
                 // Work around the empty yaml file issue.
                 // See https://github.com/dtolnay/serde-yaml/issues/86
                 if e.to_string() != "EOF while parsing a value" {
-                    panic!(e.to_string())
+                    panic!("{}", e.to_string())
                 }
                 Config::default()
             }


### PR DESCRIPTION
[wezterm](https://wezfurlong.org/wezterm/) is a GPU-accelerated, highly configurable terminal emulator.

I need help with creating the temporary file, it doesn't exist/is deleted before wezterm starts. When `load_term_conf` is set to `false`, I get:
![image](https://user-images.githubusercontent.com/36493671/118020392-a70c1880-b377-11eb-8429-d98f758d6e28.png)

`cargo test` passes and the wezterm backend works properly (other than the above issue)