### PR TITLE
Allow to specify the Neovim program or its path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "glrnvim"
 version = "1.2.0"
 authors = ["beeender <chenmulong@gmail.com>"]
 edition = "2018"
+description = "glrnvim combines OpenGL (possibly), Rust and NeoVIM together, to make the fastest, simplest neovim GUI."
+readme = "README.md"
+license = "GPL-3.0"
 
 [dependencies]
 regex = "1"

--- a/glrnvim.yml
+++ b/glrnvim.yml
@@ -2,11 +2,16 @@
 
 # Choose the backend terminal to run neovim in.
 # Current supported terminals: alacritty, urxvt, kitty.
-#
 #backend: urxvt
+
 # path to backend executable file
 # NOTE: requires a backend key
-#exe_path: /path/to/urxvt
+# NOTE: old key exe_path is now deprecated but can still be used
+#term_exe_path: /path/to/urxvt
+
+# Specify the Neovim executable path.
+# NOTE: nvim will be used if not specified
+#nvim_exec_path: /path/to/nvim
 
 # The fonts to be used. Multi fonts can be supplied.
 # The first one will be set as the major font. Others will be set as

--- a/src/backend/alacritty.rs
+++ b/src/backend/alacritty.rs
@@ -1,7 +1,6 @@
 use super::Functions;
 use crate::config::Config;
 use crate::error::GlrnvimError;
-use crate::NVIM_NAME;
 use regex::Regex;
 use std::fs;
 use std::path::PathBuf;
@@ -16,7 +15,7 @@ struct Alacritty {
 }
 
 pub fn init(config: &Config) -> Result<Box<dyn Functions>, GlrnvimError> {
-    let exe_path = super::exe_path(&config.exe_path, ALACRITTY_NAME)?;
+    let exe_path = super::exe_path(&config.term_exe_path, ALACRITTY_NAME)?;
 
     Ok(Box::new(Alacritty {
         exe_path,
@@ -133,7 +132,7 @@ impl Functions for Alacritty {
         }
 
         command.arg("-e");
-        command.arg(NVIM_NAME);
+        command.arg(&config.nvim_exe_path);
         command.args(super::COMMON_ARGS);
 
         command
@@ -152,7 +151,9 @@ mod tests {
         let conf = config::Config {
             fork: false,
             backend: Some(config::Backend::Alacritty),
+            term_exe_path: None,
             exe_path: None,
+            nvim_exe_path: "nvim".to_owned(),
             font_size: 14,
             fonts: vec!["test_font".to_string()],
             load_term_conf: false,
@@ -194,7 +195,9 @@ key_bindings:
         let conf = config::Config {
             fork: false,
             backend: Some(config::Backend::Alacritty),
+            term_exe_path: None,
             exe_path: None,
+            nvim_exe_path: "nvim".to_owned(),
             font_size: 14,
             fonts: vec!["test_font".to_string()],
             load_term_conf: false,
@@ -236,7 +239,9 @@ key_bindings:
         let conf = config::Config {
             fork: false,
             backend: Some(config::Backend::Alacritty),
+            term_exe_path: None,
             exe_path: None,
+            nvim_exe_path: "nvim".to_owned(),
             font_size: 0,
             fonts: vec![],
             load_term_conf: false,
@@ -281,7 +286,9 @@ key_bindings:
         let conf = config::Config {
             fork: false,
             backend: Some(config::Backend::Alacritty),
+            term_exe_path: None,
             exe_path: None,
+            nvim_exe_path: "nvim".to_owned(),
             font_size: 0,
             fonts: vec![],
             load_term_conf: false,

--- a/src/backend/alacritty.rs
+++ b/src/backend/alacritty.rs
@@ -46,15 +46,10 @@ impl Alacritty {
         // Set the font
         if !config.fonts.is_empty() {
             let mut normal_mapping = serde_yaml::Mapping::new();
-            for font in &config.fonts {
-                normal_mapping.insert(
-                    serde_yaml::to_value("family").unwrap(),
-                    serde_yaml::to_value(font).unwrap(),
-                );
-                // TODO: Alacritty doesn't support fallback font well.
-                // See https://github.com/jwilm/alacritty/issues/957
-                break;
-            }
+            normal_mapping.insert(
+                serde_yaml::to_value("family").unwrap(),
+                serde_yaml::to_value(&config.fonts.first()).unwrap(),
+            );
             font_mapping.insert(
                 serde_yaml::to_value("normal").unwrap(),
                 serde_yaml::to_value(normal_mapping).unwrap(),
@@ -98,7 +93,7 @@ impl Alacritty {
             "$XDG_CONFIG_DIRS/alacritty/alacritty.yml".to_string(),
         ];
         let confs = super::find_term_conf_files(&base_confs, &pri_confs);
-        if confs.len() > 0 {
+        if !confs.is_empty() {
             let path = confs[0].to_owned();
             let file = std::fs::File::open(path).unwrap();
             let reader = std::io::BufReader::new(file);

--- a/src/backend/kitty.rs
+++ b/src/backend/kitty.rs
@@ -61,14 +61,14 @@ impl Kitty {
             "$HOME/.config/kitty/kitty.conf".to_string(),
             "$XDG_CONFIG_DIRS/kitty/kitty.conf".to_string(),
         ];
-        return super::find_term_conf_files(&base_confs, &pri_confs);
+        super::find_term_conf_files(&base_confs, &pri_confs)
     }
 }
 
 impl Functions for Kitty {
     fn create_command(&mut self, config: &Config) -> std::process::Command {
         self.create_conf_file(config);
-        
+
         let mut command = std::process::Command::new(self.exe_path.to_owned());
 
         if config.load_term_conf {

--- a/src/backend/kitty.rs
+++ b/src/backend/kitty.rs
@@ -1,7 +1,6 @@
 use super::Functions;
 use crate::config::Config;
 use crate::error::GlrnvimError;
-use crate::NVIM_NAME;
 use std::io::Write;
 use std::path::PathBuf;
 use tempfile::NamedTempFile;
@@ -14,7 +13,7 @@ struct Kitty {
 }
 
 pub fn init(config: &Config) -> Result<Box<dyn Functions>, GlrnvimError> {
-    let exe_path = super::exe_path(&config.exe_path, KITTY_NAME)?;
+    let exe_path = super::exe_path(&config.term_exe_path, KITTY_NAME)?;
 
     Ok(Box::new(Kitty {
         exe_path,
@@ -35,7 +34,7 @@ impl Kitty {
             writeln!(file, "font_size {}", config.font_size).unwrap();
         }
 
-        if config.load_term_conf {
+        if !config.load_term_conf {
             writeln!(file, "clear_all_shortcuts yes").unwrap();
         }
         // Using no_op to bypass ctrl-z seems not working.
@@ -69,6 +68,7 @@ impl Kitty {
 impl Functions for Kitty {
     fn create_command(&mut self, config: &Config) -> std::process::Command {
         self.create_conf_file(config);
+        
         let mut command = std::process::Command::new(self.exe_path.to_owned());
 
         if config.load_term_conf {
@@ -87,7 +87,7 @@ impl Functions for Kitty {
             command.arg("glrnvim");
         }
 
-        command.arg(NVIM_NAME);
+        command.arg(&config.nvim_exe_path);
         command.args(super::COMMON_ARGS);
 
         command

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -12,7 +12,7 @@ pub trait Functions {
     fn create_command(&mut self, config: &Config) -> std::process::Command;
 }
 
-const COMMON_ARGS: &'static [&'static str] = &[
+const COMMON_ARGS: &[&str] = &[
     "+set termguicolors", // Enable 24-bits colors
     "+set title",         // Set title string
     "--cmd",
@@ -29,15 +29,14 @@ pub fn init(config: &Config) -> Result<Box<dyn Functions>, GlrnvimError> {
         },
         None => {
             for init_func in &[alacritty::init, urxvt::init, kitty::init, wezterm::init] {
-                match init_func(config) {
-                    Ok(functions) => return Ok(functions),
-                    Err(_) => {}
+                if let Ok(functions) = init_func(config) {
+                    return Ok(functions);
                 }
             }
 
-            Err(GlrnvimError::new(format!(
-                "None of the suppported terminals can be found.",
-            )))
+            Err(GlrnvimError::new(
+                "None of the suppported terminals can be found.".to_string(),
+            ))
         }
     }
 }
@@ -112,5 +111,5 @@ fn find_term_conf_files(base_confs: &[String], priority_confs: &[String]) -> Vec
         }
     }
 
-    return ret;
+    ret
 }

--- a/src/backend/urxvt.rs
+++ b/src/backend/urxvt.rs
@@ -1,7 +1,6 @@
 use super::Functions;
 use crate::config::Config;
 use crate::error::GlrnvimError;
-use crate::NVIM_NAME;
 use std::path::PathBuf;
 
 pub const URXVT_NAME: &str = "urxvt";
@@ -12,7 +11,7 @@ struct Urxvt {
 }
 
 pub fn init(config: &Config) -> Result<Box<dyn Functions>, GlrnvimError> {
-    let exe_path = super::exe_path(&config.exe_path, URXVT_NAME)?;
+    let exe_path = super::exe_path(&config.term_exe_path, URXVT_NAME)?;
 
     Ok(Box::new(Urxvt {
         exe_path,
@@ -51,7 +50,7 @@ impl Functions for Urxvt {
         command.arg("builtin-string:");
         command.args(&self.args);
         command.arg("-e");
-        command.arg(NVIM_NAME);
+        command.arg(&config.nvim_exe_path);
         command.args(super::COMMON_ARGS);
         command
     }

--- a/src/backend/wezterm.rs
+++ b/src/backend/wezterm.rs
@@ -1,7 +1,6 @@
 use super::Functions;
 use crate::config::Config;
 use crate::error::GlrnvimError;
-use crate::NVIM_NAME;
 use std::io::Write;
 use std::path::PathBuf;
 use tempfile::NamedTempFile;
@@ -15,7 +14,7 @@ struct Wezterm {
 }
 
 pub fn init(config: &Config) -> Result<Box<dyn Functions>, GlrnvimError> {
-    let exe_path = super::exe_path(&config.exe_path, WEZTERM_NAME)?;
+    let exe_path = super::exe_path(&config.term_exe_path, WEZTERM_NAME)?;
 
     Ok(Box::new(Wezterm {
         exe_path,
@@ -67,7 +66,7 @@ impl Functions for Wezterm {
         command.arg("--class");
         command.arg("glrnvim");
         command.arg("--");
-        command.arg(NVIM_NAME);
+        command.arg(&config.nvim_exe_path);
         command.args(super::COMMON_ARGS);
         command
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,7 +67,7 @@ pub fn parse(path: PathBuf) -> Config {
         panic!("term_exe_path requires a backend key")
     }
 
-    if config.nvim_exe_path == "" {
+    if config.nvim_exe_path.is_empty() {
         config.nvim_exe_path = NVIM_NAME.to_owned()
     }
 
@@ -157,7 +157,8 @@ fonts:
 
     #[test]
     fn test_parse_backend_and_term_exe_path() {
-        let config = parse(make_cfg_file("backend: alacritty\nterm_exe_path: /path/to/alacritty").path);
+        let config =
+            parse(make_cfg_file("backend: alacritty\nterm_exe_path: /path/to/alacritty").path);
         assert_eq!(config.backend, Some(Backend::Alacritty));
         assert_eq!(config.term_exe_path, Some("/path/to/alacritty".to_string()));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use config::*;
 use std::env;
 use std::process::Command;
 
-pub const NVIM_NAME: &str = "nvim";
 const DEFAULT_FONT_SIZE: u8 = 12;
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
@@ -27,9 +26,9 @@ fn prepare_env() {
     env::remove_var("TERM_PROGRAM_VERSION");
 }
 
-fn check_nvim() {
-    if which::which(NVIM_NAME).is_err() {
-        eprintln!("'{}' executable cannot be found.", NVIM_NAME);
+fn check_nvim(vim_exe_path: &str) {
+    if which::which(vim_exe_path).is_err() {
+        eprintln!("'{}' executable cannot be found.", vim_exe_path);
         std::process::exit(-1);
     }
 }
@@ -138,8 +137,8 @@ fn show_help() {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
-    check_nvim();
     let (config, n_args) = parse_args();
+    check_nvim(&config.nvim_exe_path);
 
     let mut backend_functions = backend::init(&config)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use std::process::Command;
 
 const DEFAULT_FONT_SIZE: u8 = 12;
 
-const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg(not(target_os = "macos"))]
 fn prepare_env() {}
@@ -38,8 +38,7 @@ fn parse_args() -> (Config, Vec<String>) {
     let mut n_args: Vec<String> = Vec::new();
     let mut fork: bool = true;
 
-    for i in 1..args.len() {
-        let arg = &args[i];
+    for arg in args.iter().skip(1) {
         if arg.starts_with("-h") || arg.starts_with("--help") {
             show_help();
             std::process::exit(0);
@@ -59,7 +58,7 @@ fn parse_args() -> (Config, Vec<String>) {
             new_conf_path.push("glrnvim");
             new_conf_path.push("config.yml");
 
-            let mut old_conf_path = conf_dir.clone();
+            let mut old_conf_path = conf_dir;
             old_conf_path.push("glrnvim.yml");
 
             if new_conf_path.exists() {


### PR DESCRIPTION
Hello,
I'd like to be able to configure the executable name or path of nvim since I use a pretty weird configuration 😄 .

I have made the necessary change to add a new optional configuration option `nvim_exe_path` to setup the exe or its path. I have also rename the option `exe_path` to `term_exe_path` (`exe_path` still works with a lower priority). If you are ok with a breaking change in the config system I can remove the `exe_path` option.

I have also applied a couple of fixes here and there, most of them from clippy.

Thanks, I love glrnvim!