### PR TITLE
Fix nvim start args for Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ CHANGES
 
 Next Release
 
+- Fix nvim start args for Windows. (#45)
+
 1.3.0
 
 - [Deprecated] The config path is changed from `$HOME/config/glrnvim.yml` to `$HOME/config/glrnvim/config.yml`. The old config path is still supported with a lower priority.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -12,11 +12,19 @@ pub trait Functions {
     fn create_command(&mut self, config: &Config) -> std::process::Command;
 }
 
+#[cfg(not(target_os = "windows"))]
 const COMMON_ARGS: &[&str] = &[
     "+set termguicolors", // Enable 24-bits colors
     "+set title",         // Set title string
     "--cmd",
     "let g:glrnvim_gui=1",
+];
+#[cfg(target_os = "windows")]
+const COMMON_ARGS: &[&str] = &[
+    "\"+set termguicolors\"", // Enable 24-bits colors
+    "\"+set title\"",         // Set title string
+    "\"--cmd\"",
+    "\"let g:glrnvim_gui=1\"",
 ];
 
 pub fn init(config: &Config) -> Result<Box<dyn Functions>, GlrnvimError> {


### PR DESCRIPTION
This is reported by #45.
A pair of quotes are needed for the nvim start commands args.
