### PR TITLE
Fix various minor issues with config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ CHANGES
 Next Release
 
 - Fix nvim start args for Windows. (#45)
+- Show the config path hint in `help`.
 
 1.3.0
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -20,7 +20,7 @@ package_glrnvim() {
 	env CARGO_INCREMENTAL=0 cargo build --release
 
 	install -Dm755 "$srcdir/$_pkgname/target/release/glrnvim" "$pkgdir/usr/bin/glrnvim"
-    install -Dm644 $srcdir/$_pkgname/glrnvim.yml "$pkgdir/usr/share/doc/glrnvim/example/glrnvim.yml"
+    install -Dm644 $srcdir/$_pkgname/config.yml "$pkgdir/usr/share/doc/glrnvim/example/config.yml"
     install -Dm644 $srcdir/$_pkgname/glrnvim.desktop "$pkgdir/usr/share/applications/glrnvim.desktop"
     install -Dm644 $srcdir/$_pkgname/glrnvim.svg "$pkgdir/usr/share/icons/glrnvim.svg"
 }

--- a/README.md
+++ b/README.md
@@ -45,22 +45,17 @@ cargo deb --install
 
 ## Build
 
-### Linux & macOS
-
 ```sh
 cargo build
 ```
 
-## Windows
-
-Not difficult, just try.
-
 ## Configuration
 
-Modify [example config](https://github.com/beeender/glrnvim/blob/master/glrnvim.yml) and copy it to your `XDG_CONFIG_HOME` directory.
+Modify [example config](https://github.com/beeender/glrnvim/blob/master/config.yml) and copy it to your `XDG_CONFIG_HOME` directory.
 
 - For Linux: `$HOME/.config/glrnvim/config.yml`
 - For MacOS: `$HOME/Library/Preferences/glrnvim/config.yml`
+- For Windows: `{FOLDERID_RoamingAppData}` (`C:\Users\Alice\AppData\Roaming\glrnvim\config.yml`)
 
 ## Tips
 

--- a/config.yml
+++ b/config.yml
@@ -11,7 +11,8 @@
 
 # Specify the Neovim executable path.
 # NOTE: nvim will be used if not specified
-#nvim_exec_path: /path/to/nvim
+# NOTE: For windows, e.g.: C:\tools\neovim\Neovim\bin\nvim.exe
+#nvim_exe_path: /path/to/nvim
 
 # The fonts to be used. Multi fonts can be supplied.
 # The first one will be set as the major font. Others will be set as
@@ -27,7 +28,7 @@
 
 # Set to true if the terminal's default configuration should be loaded
 # first. Other glrnvim configurations will overwrite the terminal settings
-# if they are set in glrnvim.yml.
+# if they are set in config.yml.
 # urxvt is not impacted by this setting. It always load resources according
 # to the defined orders.
 #load_term_conf: false

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,8 +130,18 @@ fn show_help() {
         println!("{}", line);
     }
 
-    println!("\nConfig file: $HOME/.config/glrnvim.yml");
-    println!("See https://github.com/beeender/glrnvim/blob/master/glrnvim.yml for example.");
+    match dirs::config_dir() {
+        Some(conf_dir) => {
+            let mut conf_path = conf_dir.clone();
+            conf_path.push("glrnvim");
+            conf_path.push("config.yml");
+            println!("\nConfig file: {}", conf_path.display().to_string());
+            println!("See https://github.com/beeender/glrnvim/blob/master/glrnvim.yml for example.");
+        }
+        None => {
+            println!("\nConfig file: Cannot identify the current config directory. No config file can be loaded.");
+        }
+    };
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
- Rename the example config file to adapt the path change.
- Modify the README for Windows build.
- Show the config path hint based on the current OS.
- Add a path example in the config for Windows to close #45.
