### PR TITLE
Allow to specify a configuration file for mutliple terminal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ CHANGES
 
 Next Release
 
+* Allow to specify a configuration file path for Kitty, Wezterm and Alacritty inside
+  config.yml
+
 -
 
 1.3.1

--- a/config.yml
+++ b/config.yml
@@ -4,10 +4,14 @@
 # Current supported terminals: alacritty, urxvt, kitty, wezterm.
 #backend: urxvt
 
-# path to backend executable file
+# Path to backend executable file
 # NOTE: requires a backend key
 # NOTE: old key exe_path is now deprecated but can still be used
 #term_exe_path: /path/to/urxvt
+
+# Configuration file for the selected terminal.
+# This option is not supported by urxvt.
+#term_config_path: /path/to/config.yaml
 
 # Specify the Neovim executable path.
 # NOTE: nvim will be used if not specified

--- a/src/backend/alacritty.rs
+++ b/src/backend/alacritty.rs
@@ -120,7 +120,7 @@ impl Functions for Alacritty {
         };
 
         self.create_conf_file(&mut base_conf, config);
-        let mut command = std::process::Command::new(self.exe_path.to_owned());
+        let mut command = std::process::Command::new(&self.exe_path);
         command.arg("--config-file");
         command.arg(self.cfg_file.as_ref().unwrap().path());
         command.arg("--class");

--- a/src/backend/kitty.rs
+++ b/src/backend/kitty.rs
@@ -71,16 +71,19 @@ impl Functions for Kitty {
 
         let mut command = std::process::Command::new(&self.exe_path);
 
-        if config.load_term_conf {
+        if let Some(config_path) = config.term_config_path.as_ref() {
+            command.arg("--config");
+            command.arg(config_path.as_str());
+        } else if config.load_term_conf {
             let confs = Kitty::find_default_confs();
             for conf in confs {
                 command.arg("--config");
                 command.arg(conf);
             }
+        } else {
+            command.arg("--config");
+            command.arg(self.temp_file.as_ref().unwrap().path());
         }
-
-        command.arg("--config");
-        command.arg(self.temp_file.as_ref().unwrap().path());
 
         if cfg!(target_os = "linux") {
             command.arg("--class");

--- a/src/backend/kitty.rs
+++ b/src/backend/kitty.rs
@@ -69,7 +69,7 @@ impl Functions for Kitty {
     fn create_command(&mut self, config: &Config) -> std::process::Command {
         self.create_conf_file(config);
 
-        let mut command = std::process::Command::new(self.exe_path.to_owned());
+        let mut command = std::process::Command::new(&self.exe_path);
 
         if config.load_term_conf {
             let confs = Kitty::find_default_confs();

--- a/src/backend/urxvt.rs
+++ b/src/backend/urxvt.rs
@@ -41,7 +41,7 @@ impl Urxvt {
 impl Functions for Urxvt {
     fn create_command(&mut self, config: &Config) -> std::process::Command {
         self.init_args(config);
-        let mut command = std::process::Command::new(self.exe_path.to_owned());
+        let mut command = std::process::Command::new(&self.exe_path);
 
         command.arg("-name");
         command.arg("glrnvim");

--- a/src/backend/wezterm.rs
+++ b/src/backend/wezterm.rs
@@ -55,7 +55,7 @@ impl Wezterm {
 impl Functions for Wezterm {
     fn create_command(&mut self, config: &Config) -> std::process::Command {
         self.init_args(config);
-        let mut command = std::process::Command::new(self.exe_path.to_owned());
+        let mut command = std::process::Command::new(&self.exe_path);
         command.args(&self.args);
         if !config.load_term_conf {
             self.create_conf_file();

--- a/src/backend/wezterm.rs
+++ b/src/backend/wezterm.rs
@@ -10,7 +10,6 @@ pub const WEZTERM_NAME: &str = "wezterm";
 struct Wezterm {
     exe_path: PathBuf,
     pub args: Vec<String>,
-    temp_file: Option<NamedTempFile>,
 }
 
 pub fn init(config: &Config) -> Result<Box<dyn Functions>, GlrnvimError> {
@@ -19,7 +18,6 @@ pub fn init(config: &Config) -> Result<Box<dyn Functions>, GlrnvimError> {
     Ok(Box::new(Wezterm {
         exe_path,
         args: vec![],
-        temp_file: None,
     }))
 }
 
@@ -44,11 +42,12 @@ impl Wezterm {
         self.args.push("--config".to_string());
         self.args.push("enable_tab_bar = false".to_string());
     }
-    fn create_conf_file(&mut self) {
+
+    fn create_conf_file(&mut self) -> NamedTempFile {
         let mut file = tempfile::NamedTempFile::new().unwrap();
         writeln!(file, "return {{}}").unwrap();
         file.flush().unwrap();
-        self.temp_file = Some(file);
+        file
     }
 }
 
@@ -57,10 +56,13 @@ impl Functions for Wezterm {
         self.init_args(config);
         let mut command = std::process::Command::new(&self.exe_path);
         command.args(&self.args);
-        if !config.load_term_conf {
-            self.create_conf_file();
+        if let Some(config_path) = config.term_config_path.as_ref() {
             command.arg("--config-file");
-            command.arg(self.temp_file.as_ref().unwrap().path());
+            command.arg(config_path);
+        } else if !config.load_term_conf {
+            let temp_file = self.create_conf_file();
+            command.arg("--config-file");
+            command.arg(temp_file.path());
         }
         command.arg("start");
         command.arg("--class");

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,7 @@ pub struct Config {
     // TODO: this config option is deprecated, will be removed in the future
     pub exe_path: Option<String>,
     pub term_exe_path: Option<String>,
+    pub term_config_path: Option<String>,
     #[serde(default)]
     pub nvim_exe_path: String,
     #[serde(default)]
@@ -41,6 +42,7 @@ impl Default for Config {
             nvim_exe_path: NVIM_NAME.to_owned(),
             exe_path: None,
             term_exe_path: None,
+            term_config_path: None,
             fonts: Vec::new(),
             font_size: 0,
             load_term_conf: false,

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,8 +108,8 @@ mod tests {
         let dir = tempdir().unwrap();
 
         let file_path = dir.path().join("glrnvim.yaml");
-        let mut file = File::create(file_path.to_owned()).unwrap();
-        file.write(content.as_bytes()).unwrap();
+        let mut file = File::create(&file_path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
         file.flush().unwrap();
         drop(file);
         TempConfFile {

--- a/src/config.rs
+++ b/src/config.rs
@@ -158,12 +158,14 @@ fonts:
     }
 
     #[test]
-    fn test_parse_backend_and_term_exe_path() {
+    fn test_parse_backend_and_term_exe_path_and_term_config_path() {
         let config =
-            parse(make_cfg_file("backend: alacritty\nterm_exe_path: /path/to/alacritty").path);
+            parse(make_cfg_file("backend: alacritty\nterm_exe_path: /path/to/alacritty\nterm_config_path: /path/to/config").path);
         assert_eq!(config.backend, Some(Backend::Alacritty));
         assert_eq!(config.term_exe_path, Some("/path/to/alacritty".to_string()));
+        assert_eq!(config.term_config_path, Some("/path/to/config".to_string()));
     }
+
 
     #[test]
     fn test_parse_backend_and_deprecated_exe_path() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,11 +133,11 @@ fn show_help() {
     }
 
     match dirs::config_dir() {
-        Some(conf_dir) => {
-            let mut conf_path = conf_dir.clone();
-            conf_path.push("glrnvim");
-            conf_path.push("config.yml");
-            println!("\nConfig file: {}", conf_path.display().to_string());
+        Some(mut conf_dir) => {
+            // let mut conf_path = conf_dir.clone();
+            conf_dir.push("glrnvim");
+            conf_dir.push("config.yml");
+            println!("\nConfig file: {}", conf_dir.display());
             println!("See https://github.com/beeender/glrnvim/blob/master/glrnvim.yml for example.");
         }
         None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,6 @@ fn show_help() {
 
     match dirs::config_dir() {
         Some(mut conf_dir) => {
-            // let mut conf_path = conf_dir.clone();
             conf_dir.push("glrnvim");
             conf_dir.push("config.yml");
             println!("\nConfig file: {}", conf_dir.display());


### PR DESCRIPTION
This PR introduces a new configuration option `term_config_path`. If set, terminal supporting configuration via command line use `term_config_path` as configuration path.

This allows me to have a different Kitty config which disables some keymapping I was to pass through vim.