### PR TITLE
Call set command before any nvim config

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -18,15 +18,19 @@ pub trait Functions {
 
 #[cfg(not(target_os = "windows"))]
 const COMMON_ARGS: &[&str] = &[
-    "+set termguicolors", // Enable 24-bits colors
-    "+set title",         // Set title string
+    "--cmd",
+    "set termguicolors", // Enable 24-bits colors
+    "--cmd",
+    "set title",         // Set title string
     "--cmd",
     "let g:glrnvim_gui=1",
 ];
 #[cfg(target_os = "windows")]
 const COMMON_ARGS: &[&str] = &[
-    "\"+set termguicolors\"", // Enable 24-bits colors
-    "\"+set title\"",         // Set title string
+    "\"--cmd\"",
+    "\"set termguicolors\"", // Enable 24-bits colors
+    "\"--cmd\"",
+    "\"set title\"",         // Set title string
     "\"--cmd\"",
     "\"let g:glrnvim_gui=1\"",
 ];


### PR DESCRIPTION
"+set termguicolors" or any other set command will cause issues with alpha-nvim.
https://github.com/goolord/alpha-nvim

The side effect is that user may overwrite the config in their rc file.
But user can do that anyway after glrnvim starts. So it is desired.

Fix #57
