### PR TITLE
Specify a config file for most terminals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ CHANGES
 
 Next Release
 
+* Allow to specify a configuration file path for Kitty, Wezterm and Alacritty inside
+  config.yml
+
 -
 
 1.3.1

--- a/config.yml
+++ b/config.yml
@@ -4,7 +4,7 @@
 # Current supported terminals: alacritty, urxvt, kitty, wezterm.
 #backend: urxvt
 
-# path to backend executable file
+# Path to backend executable file
 # NOTE: requires a backend key
 # NOTE: old key exe_path is now deprecated but can still be used
 #term_exe_path: /path/to/urxvt
@@ -32,3 +32,10 @@
 # urxvt is not impacted by this setting. It always load resources according
 # to the defined orders.
 #load_term_conf: false
+
+# Configuration file for the selected terminal.
+# NOTE:This option is not supported by urxvt.
+# If this option is specified, the terminal's default config won't be loaded
+# when 'load_term_conf' is true.
+#term_config_path: /path/to/config.yaml
+

--- a/src/backend/kitty.rs
+++ b/src/backend/kitty.rs
@@ -69,9 +69,12 @@ impl Functions for Kitty {
     fn create_command(&mut self, config: &Config) -> std::process::Command {
         self.create_conf_file(config);
 
-        let mut command = std::process::Command::new(self.exe_path.to_owned());
+        let mut command = std::process::Command::new(&self.exe_path);
 
-        if config.load_term_conf {
+        if let Some(config_path) = config.term_config_path.as_ref() {
+            command.arg("--config");
+            command.arg(config_path.as_str());
+        } else if config.load_term_conf {
             let confs = Kitty::find_default_confs();
             for conf in confs {
                 command.arg("--config");
@@ -79,6 +82,7 @@ impl Functions for Kitty {
             }
         }
 
+        // Overwrite the config with the generated settings from glrnvim.yml
         command.arg("--config");
         command.arg(self.temp_file.as_ref().unwrap().path());
 

--- a/src/backend/urxvt.rs
+++ b/src/backend/urxvt.rs
@@ -41,7 +41,7 @@ impl Urxvt {
 impl Functions for Urxvt {
     fn create_command(&mut self, config: &Config) -> std::process::Command {
         self.init_args(config);
-        let mut command = std::process::Command::new(self.exe_path.to_owned());
+        let mut command = std::process::Command::new(&self.exe_path);
 
         command.arg("-name");
         command.arg("glrnvim");

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 const NVIM_NAME: &str = "nvim";
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Backend {
     Alacritty,
@@ -15,7 +15,7 @@ pub enum Backend {
     Wezterm,
 }
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 pub struct Config {
     #[serde(skip)]
     pub fork: bool,
@@ -23,6 +23,7 @@ pub struct Config {
     // TODO: this config option is deprecated, will be removed in the future
     pub exe_path: Option<String>,
     pub term_exe_path: Option<String>,
+    pub term_config_path: Option<String>,
     #[serde(default)]
     pub nvim_exe_path: String,
     #[serde(default)]
@@ -41,6 +42,7 @@ impl Default for Config {
             nvim_exe_path: NVIM_NAME.to_owned(),
             exe_path: None,
             term_exe_path: None,
+            term_config_path: None,
             fonts: Vec::new(),
             font_size: 0,
             load_term_conf: false,
@@ -108,8 +110,8 @@ mod tests {
         let dir = tempdir().unwrap();
 
         let file_path = dir.path().join("glrnvim.yaml");
-        let mut file = File::create(file_path.to_owned()).unwrap();
-        file.write(content.as_bytes()).unwrap();
+        let mut file = File::create(&file_path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
         file.flush().unwrap();
         drop(file);
         TempConfFile {
@@ -156,12 +158,14 @@ fonts:
     }
 
     #[test]
-    fn test_parse_backend_and_term_exe_path() {
+    fn test_parse_backend_and_term_exe_path_and_term_config_path() {
         let config =
-            parse(make_cfg_file("backend: alacritty\nterm_exe_path: /path/to/alacritty").path);
+            parse(make_cfg_file("backend: alacritty\nterm_exe_path: /path/to/alacritty\nterm_config_path: /path/to/config").path);
         assert_eq!(config.backend, Some(Backend::Alacritty));
         assert_eq!(config.term_exe_path, Some("/path/to/alacritty".to_string()));
+        assert_eq!(config.term_config_path, Some("/path/to/config".to_string()));
     }
+
 
     #[test]
     fn test_parse_backend_and_deprecated_exe_path() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,11 +133,10 @@ fn show_help() {
     }
 
     match dirs::config_dir() {
-        Some(conf_dir) => {
-            let mut conf_path = conf_dir.clone();
-            conf_path.push("glrnvim");
-            conf_path.push("config.yml");
-            println!("\nConfig file: {}", conf_path.display().to_string());
+        Some(mut conf_dir) => {
+            conf_dir.push("glrnvim");
+            conf_dir.push("config.yml");
+            println!("\nConfig file: {}", conf_dir.display());
             println!("See https://github.com/beeender/glrnvim/blob/master/glrnvim.yml for example.");
         }
         None => {


### PR DESCRIPTION
- Add 'term_config_path' to specify a config file for
  alacritty/wezterm/kitty.
- glrnvim will overwrite the config if needed.
