### PR TITLE
Wrap env::remove_var calls in unsafe blocks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,9 +22,9 @@ fn prepare_env() {}
 fn prepare_env() {
     // When starting from iTerm, these env vars could cause some display issues.
     log::debug!("unset $TERM_PROGRAM");
-    env::remove_var("TERM_PROGRAM");
+    unsafe { env::remove_var("TERM_PROGRAM") };
     log::debug!("unset $TERM_PROGRAM_VERSION");
-    env::remove_var("TERM_PROGRAM_VERSION");
+    unsafe { env::remove_var("TERM_PROGRAM_VERSION") };
 }
 
 fn check_nvim(vim_exe_path: &str) {


### PR DESCRIPTION
env::remove_var is newly marked unsafe in the 2024 edition due to its inherent unreliability in multithreaded contexts.

This code is single-threaded so there should be no problem.

See https://doc.rust-lang.org/edition-guide/rust-2024/newly-unsafe-functions.html#stdenvset_var-remove_var

Fixes #80 